### PR TITLE
Check source and target node types on match_relationships() for case where multiple different relationships use same relationship_type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neontolojay"
-version = "2025.0.0b2"
+version = "2025.0.0b3"
 requires-python = ">=3.9"
 description = "A Python package for modelling data in a Neo4j graph database with Pydantic and Pandas. A fork of neontology with added support for non-unique primary keys."
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ markers = [
 ]
 testpaths = ["tests"]
 pythonpath = ["src"]
+filterwarnings = [
+    "ignore:Duplicate dictionary key PRACTICE_RELATIONSHIP"
+]
 log_cli = 1
 log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"

--- a/src/neontology/__init__.py
+++ b/src/neontology/__init__.py
@@ -2,12 +2,12 @@
 
 from .basenode import BaseNode, related_nodes, related_property
 from .baserelationship import BaseRelationship
+from .elementidmodel import ElementIdModel
 from .gql import GQLIdentifier, gql_identifier_adapter
 from .graphconnection import GraphConnection, init_neontology
 from .graphengines.memgraphengine import MemgraphConfig
 from .graphengines.neo4jengine import Neo4jConfig
 from .utils import auto_constrain_neo4j
-from .elementidmodel import ElementIdModel
 
 __all__ = [
     # BaseNode

--- a/src/neontology/basenode.py
+++ b/src/neontology/basenode.py
@@ -105,9 +105,11 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
         # get all the properties
         all_props = params.pop("all_props")
 
-        params.update({
-            "pp": all_props[self.__primaryproperty__],
-        })
+        params.update(
+            {
+                "pp": all_props[self.__primaryproperty__],
+            }
+        )
 
         return params
 

--- a/src/neontology/baserelationship.py
+++ b/src/neontology/baserelationship.py
@@ -1,18 +1,18 @@
 import itertools
 import json
 import warnings
-from typing import Any, ClassVar, Dict, List, Optional, Type, TypeVar, Self
+from typing import Any, ClassVar, Dict, List, Optional, Self, Type, TypeVar
 
 import pandas as pd
-from pydantic import BaseModel, PrivateAttr, ValidationError, model_validator, Field
+from pydantic import BaseModel, Field, PrivateAttr, ValidationError, model_validator
 
 from neontology.graphconnection import GraphConnection
 
 from .basenode import BaseNode
 from .commonmodel import CommonModel
 from .gql import gql_identifier_adapter
-from .schema_utils import RelationshipSchema, SchemaProperty, extract_type_mapping
 from .result import NeontologyResult
+from .schema_utils import RelationshipSchema, SchemaProperty, extract_type_mapping
 
 R = TypeVar("R", bound="BaseRelationship")
 
@@ -96,13 +96,15 @@ class BaseRelationship(CommonModel):  # pyre-ignore[13]
         source_element_id_prop = getattr(self.source, "__elementidproperty__", None)
         target_element_id_prop = getattr(self.target, "__elementidproperty__", None)
 
-        params.update({
-            "source_prop": source_prop,
-            "source_element_id_prop": source_element_id_prop,
-            "target_prop": target_prop,
-            "target_element_id_prop": target_element_id_prop,
-            **merge_props,
-        })
+        params.update(
+            {
+                "source_prop": source_prop,
+                "source_element_id_prop": source_element_id_prop,
+                "target_prop": target_prop,
+                "target_element_id_prop": target_element_id_prop,
+                **merge_props,
+            }
+        )
 
         return params
 
@@ -477,8 +479,16 @@ class RelationshipTypeData(BaseModel):
     target_class: type[BaseNode]
     all_source_classes: List[type[BaseNode]]
     all_target_classes: List[type[BaseNode]]
-    
+
     def __repr_args__(self):
-        return [(k, v) for k, v in self.__dict__.items() 
-                if k not in ["source_class","target_class",
-                             "all_source_classes","all_target_classes",]]
+        return [
+            (k, v)
+            for k, v in self.__dict__.items()
+            if k
+            not in [
+                "source_class",
+                "target_class",
+                "all_source_classes",
+                "all_target_classes",
+            ]
+        ]

--- a/src/neontology/baserelationship.py
+++ b/src/neontology/baserelationship.py
@@ -477,3 +477,8 @@ class RelationshipTypeData(BaseModel):
     target_class: type[BaseNode]
     all_source_classes: List[type[BaseNode]]
     all_target_classes: List[type[BaseNode]]
+    
+    def __repr_args__(self):
+        return [(k, v) for k, v in self.__dict__.items() 
+                if k not in ["source_class","target_class",
+                             "all_source_classes","all_target_classes",]]

--- a/src/neontology/commonmodel.py
+++ b/src/neontology/commonmodel.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Set, Self
+from typing import Any, Dict, List, Self, Set
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr, model_validator
 from pydantic_core import PydanticCustomError
@@ -85,12 +85,12 @@ class CommonModel(BaseModel):
 
         return export_dict
 
-    def _get_merge_parameters_common(self, exclude: Set[str] = set()) -> Dict[str,Any]:
+    def _get_merge_parameters_common(self, exclude: Set[str] = set()) -> Dict[str, Any]:
         """Input an all properties dictionary, and filter based on property types.
 
-            Returns:
-                Dict[str, Any]: Dictionary of always_set, set_on_match, and set_on_create dictionaries
-            """
+        Returns:
+            Dict[str, Any]: Dictionary of always_set, set_on_match, and set_on_create dictionaries
+        """
         # get all the properties
         all_props = self._engine_dict(exclude=exclude)
 
@@ -138,7 +138,7 @@ class CommonModel(BaseModel):
         result_always_set = result._get_merge_parameters_common()["always_set"]
         if not isinstance(result, type(self)):
             raise ValueError(f"Result type is {type(result)}; expected {type(self)}.")
-        for k,v in self._get_merge_parameters_common()["always_set"].items():
+        for k, v in self._get_merge_parameters_common()["always_set"].items():
             if v != result_always_set[k]:
                 raise ValueError(
                     f"Resulting {type(self)} {result.__repr__} does not match the calling object {self.__repr__}."

--- a/src/neontology/graphengines/graphengine.py
+++ b/src/neontology/graphengines/graphengine.py
@@ -238,7 +238,10 @@ class GraphEngineBase:
         from ..utils import get_node_types, get_rels_by_type
 
         rel_types = get_rels_by_type(rel_class)
-        node_classes = get_node_types()
+        node_classes = get_node_types(rel_class.model_fields['source'].annotation)
+        if (rel_class.model_fields['source'].annotation 
+            != rel_class.model_fields['target'].annotation):
+            node_classes.update(get_node_types(rel_class.model_fields['target'].annotation))
 
         return self.evaluate_query(
             cypher, params, node_classes=node_classes, relationship_classes=rel_types
@@ -319,7 +322,10 @@ class GraphEngineBase:
             params["limit"] = int_adapter.validate_python(limit)
 
         rel_types = get_rels_by_type(relationship_class)
-        node_classes = get_node_types()
+        node_classes = get_node_types(relationship_class.model_fields['source'].annotation)
+        if (relationship_class.model_fields['source'].annotation 
+            != relationship_class.model_fields['target'].annotation):
+            node_classes.update(get_node_types(relationship_class.model_fields['target'].annotation))
 
         result = self.evaluate_query(
             cypher,

--- a/src/neontology/graphengines/graphengine.py
+++ b/src/neontology/graphengines/graphengine.py
@@ -238,10 +238,14 @@ class GraphEngineBase:
         from ..utils import get_node_types, get_rels_by_type
 
         rel_types = get_rels_by_type(rel_class)
-        node_classes = get_node_types(rel_class.model_fields['source'].annotation)
-        if (rel_class.model_fields['source'].annotation 
-            != rel_class.model_fields['target'].annotation):
-            node_classes.update(get_node_types(rel_class.model_fields['target'].annotation))
+        node_classes = get_node_types(rel_class.model_fields["source"].annotation)
+        if (
+            rel_class.model_fields["source"].annotation
+            != rel_class.model_fields["target"].annotation
+        ):
+            node_classes.update(
+                get_node_types(rel_class.model_fields["target"].annotation)
+            )
 
         return self.evaluate_query(
             cypher, params, node_classes=node_classes, relationship_classes=rel_types
@@ -322,10 +326,16 @@ class GraphEngineBase:
             params["limit"] = int_adapter.validate_python(limit)
 
         rel_types = get_rels_by_type(relationship_class)
-        node_classes = get_node_types(relationship_class.model_fields['source'].annotation)
-        if (relationship_class.model_fields['source'].annotation 
-            != relationship_class.model_fields['target'].annotation):
-            node_classes.update(get_node_types(relationship_class.model_fields['target'].annotation))
+        node_classes = get_node_types(
+            relationship_class.model_fields["source"].annotation
+        )
+        if (
+            relationship_class.model_fields["source"].annotation
+            != relationship_class.model_fields["target"].annotation
+        ):
+            node_classes.update(
+                get_node_types(relationship_class.model_fields["target"].annotation)
+            )
 
         result = self.evaluate_query(
             cypher,

--- a/src/neontology/graphengines/memgraphengine.py
+++ b/src/neontology/graphengines/memgraphengine.py
@@ -1,15 +1,15 @@
 import os
-from typing import Any, ClassVar, Optional, List
+from typing import Any, ClassVar, List, Optional
 
 from dotenv import load_dotenv
 from neo4j import GraphDatabase
 from neo4j import Result as Neo4jResult
 from pydantic import model_validator
 
+from ..gql import gql_identifier_adapter
 from ..result import NeontologyResult
 from .graphengine import GraphEngineBase, GraphEngineConfig
 from .neo4jengine import neo4j_records_to_neontology_records
-from ..gql import gql_identifier_adapter
 
 
 class MemgraphEngine(GraphEngineBase):
@@ -77,7 +77,7 @@ class MemgraphEngine(GraphEngineBase):
 
         else:
             return None
-    
+
     def merge_relationships(
         self,
         source_label: str,
@@ -127,10 +127,14 @@ class MemgraphEngine(GraphEngineBase):
         from ..utils import get_node_types, get_rels_by_type
 
         rel_types = get_rels_by_type(rel_class)
-        node_classes = get_node_types(rel_class.model_fields['source'].annotation)
-        if (rel_class.model_fields['source'].annotation 
-            != rel_class.model_fields['target'].annotation):
-            node_classes.update(get_node_types(rel_class.model_fields['target'].annotation))
+        node_classes = get_node_types(rel_class.model_fields["source"].annotation)
+        if (
+            rel_class.model_fields["source"].annotation
+            != rel_class.model_fields["target"].annotation
+        ):
+            node_classes.update(
+                get_node_types(rel_class.model_fields["target"].annotation)
+            )
 
         return self.evaluate_query(
             cypher, params, node_classes=node_classes, relationship_classes=rel_types

--- a/src/neontology/graphengines/memgraphengine.py
+++ b/src/neontology/graphengines/memgraphengine.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, ClassVar, Optional
+from typing import Any, ClassVar, Optional, List
 
 from dotenv import load_dotenv
 from neo4j import GraphDatabase
@@ -9,6 +9,7 @@ from pydantic import model_validator
 from ..result import NeontologyResult
 from .graphengine import GraphEngineBase, GraphEngineConfig
 from .neo4jengine import neo4j_records_to_neontology_records
+from ..gql import gql_identifier_adapter
 
 
 class MemgraphEngine(GraphEngineBase):
@@ -76,6 +77,64 @@ class MemgraphEngine(GraphEngineBase):
 
         else:
             return None
+    
+    def merge_relationships(
+        self,
+        source_label: str,
+        target_label: str,
+        source_prop: str,
+        target_prop: str,
+        rel_type: str,
+        merge_on_props: List[str],
+        rel_props: List[dict],
+        rel_class: type["BaseRelationship"],
+    ) -> NeontologyResult:
+        # build a string of properties to merge on "prop_name: $prop_name"
+        merge_props = ", ".join(
+            [
+                f"{gql_identifier_adapter.validate_strings(x)}: rel.{x}"
+                for x in merge_on_props
+            ]
+        )
+
+        if rel_props[0]["source_element_id_prop"] == source_prop:
+            source_match_cypher = """toString(id(source))"""
+        else:
+            source_match_cypher = (
+                f"""source.{gql_identifier_adapter.validate_strings(source_prop)}"""
+            )
+        if rel_props[0]["target_element_id_prop"] == target_prop:
+            target_match_cypher = """toString(id(target))"""
+        else:
+            target_match_cypher = (
+                f"""target.{gql_identifier_adapter.validate_strings(target_prop)}"""
+            )
+        cypher = f"""
+        UNWIND $rel_list AS rel
+        MATCH (source:{gql_identifier_adapter.validate_strings(source_label)})
+        WHERE {source_match_cypher} = rel.source_prop
+        MATCH (target:{gql_identifier_adapter.validate_strings(target_label)})
+        WHERE {target_match_cypher} = rel.target_prop
+        MERGE (source)-[r:{gql_identifier_adapter.validate_strings(rel_type)} {{ {merge_props} }}]->(target)
+        ON MATCH SET r += rel.set_on_match
+        ON CREATE SET r += rel.set_on_create
+        SET r += rel.always_set
+        RETURN r, source, target
+        """
+
+        params = {"rel_list": rel_props}
+
+        from ..utils import get_node_types, get_rels_by_type
+
+        rel_types = get_rels_by_type(rel_class)
+        node_classes = get_node_types(rel_class.model_fields['source'].annotation)
+        if (rel_class.model_fields['source'].annotation 
+            != rel_class.model_fields['target'].annotation):
+            node_classes.update(get_node_types(rel_class.model_fields['target'].annotation))
+
+        return self.evaluate_query(
+            cypher, params, node_classes=node_classes, relationship_classes=rel_types
+        )
 
 
 class MemgraphConfig(GraphEngineConfig):

--- a/src/neontology/graphengines/neo4jengine.py
+++ b/src/neontology/graphengines/neo4jengine.py
@@ -78,7 +78,9 @@ def neo4j_node_to_neontology_node(
 
 
 def neo4j_relationship_to_neontology_rel(
-    neo4j_rel: Neo4jRelationship, node_classes: dict, rel_classes: dict[str,"RelationshipTypeData"]
+    neo4j_rel: Neo4jRelationship,
+    node_classes: dict,
+    rel_classes: dict[str, "RelationshipTypeData"],
 ) -> Optional["BaseRelationship"]:
     rel_type = neo4j_rel.type
     rel_type_data = rel_classes[rel_type]
@@ -110,9 +112,11 @@ def neo4j_relationship_to_neontology_rel(
     src_node = neo4j_node_to_neontology_node(neo4j_rel.start_node, node_classes)
     tgt_node = neo4j_node_to_neontology_node(neo4j_rel.end_node, node_classes)
 
-    #ensure source and target types are allowed for this relationship class
-    if not( (type(src_node) in rel_type_data.all_source_classes)
-           and (type(tgt_node) in rel_type_data.all_target_classes)):
+    # ensure source and target types are allowed for this relationship class
+    if not (
+        (type(src_node) in rel_type_data.all_source_classes)
+        and (type(tgt_node) in rel_type_data.all_target_classes)
+    ):
         return None
 
     rel_props = convert_neo4j_types(dict(neo4j_rel))

--- a/src/neontology/graphengines/neo4jengine.py
+++ b/src/neontology/graphengines/neo4jengine.py
@@ -72,13 +72,13 @@ def neo4j_node_to_neontology_node(
     # gracefully handle cases where we don't have a class defined
     # for the identified label or where we get more than one valid primary label
     else:
-        warnings.warn(f"Unexpected primary labels returned: {primary_labels}")
+        warnings.warn(f"Unexpected primary labels returned {node_labels}")
 
         return None
 
 
 def neo4j_relationship_to_neontology_rel(
-    neo4j_rel: Neo4jRelationship, node_classes: dict, rel_classes: dict
+    neo4j_rel: Neo4jRelationship, node_classes: dict, rel_classes: dict[str,"RelationshipTypeData"]
 ) -> Optional["BaseRelationship"]:
     rel_type = neo4j_rel.type
     rel_type_data = rel_classes[rel_type]
@@ -109,6 +109,11 @@ def neo4j_relationship_to_neontology_rel(
 
     src_node = neo4j_node_to_neontology_node(neo4j_rel.start_node, node_classes)
     tgt_node = neo4j_node_to_neontology_node(neo4j_rel.end_node, node_classes)
+
+    #ensure source and target types are allowed for this relationship class
+    if not( (type(src_node) in rel_type_data.all_source_classes)
+           and (type(tgt_node) in rel_type_data.all_target_classes)):
+        return None
 
     rel_props = convert_neo4j_types(dict(neo4j_rel))
     rel_props["source"] = src_node

--- a/src/neontology/utils.py
+++ b/src/neontology/utils.py
@@ -54,6 +54,8 @@ def get_rels_by_type(
 ) -> Dict[str, RelationshipTypeData]:
     rel_types: dict = defaultdict(dict)
 
+    # if we're starting with a relationship type that has a relationshiptype, include this in results
+    # if it has a relationshiptype, it is a concrete class and don't searcch subclasses
     if (
         hasattr(base_type, "__relationshiptype__")
         and base_type.__relationshiptype__ is not None
@@ -61,15 +63,15 @@ def get_rels_by_type(
         rel_types[base_type.__relationshiptype__] = generate_relationship_type_data(
             base_type
         )
-    #TODO: Check if this can be put in an ELSE to prevent further processing for a concrete rel
-    for rel_subclass in base_type.__subclasses__():
-        # we can define 'abstract' relationships which don't have a label
-        # these are to provide common properties to be used by subclassed relationships
-        # but shouldn't be put in the graph
+    else:
+        for rel_subclass in base_type.__subclasses__():
+            # we can define 'abstract' relationships which don't have a label
+            # these are to provide common properties to be used by subclassed relationships
+            # but shouldn't be put in the graph
 
-        subclass_rel_types = get_rels_by_type(rel_subclass)
+            subclass_rel_types = get_rels_by_type(rel_subclass)
 
-        update_non_existing_inplace(rel_types, subclass_rel_types)
+            update_non_existing_inplace(rel_types, subclass_rel_types)
 
     return rel_types
 

--- a/src/neontology/utils.py
+++ b/src/neontology/utils.py
@@ -25,11 +25,11 @@ def get_node_types(base_type: Type[BaseNode] = BaseNode) -> Dict[str, Type[BaseN
             # but shouldn't be put in the graph
             subclass_node_types = get_node_types(subclass)
 
-            #TODO: the update on existing causes weird class leakage failure in pytest 
-            ## When test_basenode and test_baserelationship are run sequentially
-            #update_non_existing_inplace(node_types, subclass_node_types)
+            # TODO: the update on existing causes weird class leakage failure in pytest
+            #   When test_basenode and test_baserelationship are run sequentially
+            # update_non_existing_inplace(node_types, subclass_node_types)
             node_types.update(subclass_node_types)
-    
+
     return node_types
 
 
@@ -75,14 +75,21 @@ def get_rels_by_type(
 
     return rel_types
 
+
 def update_non_existing_inplace(original_dict: dict, to_add: dict) -> None:
     for key in to_add.keys():
         if key not in original_dict:
             original_dict[key] = to_add[key]
         else:
             import warnings
-            warnings.warn(UserWarning(f'Duplicate dictionary key {key} ignored.'
-                                      f' Requested {to_add[key]}, but already has {original_dict[key]}'))
+
+            warnings.warn(
+                UserWarning(
+                    f"Duplicate dictionary key {key} ignored."
+                    f" Requested {to_add[key]}, but already has {original_dict[key]}"
+                )
+            )
+
 
 def all_subclasses(cls: type) -> set:
     return set(cls.__subclasses__()).union(

--- a/tests/test_basenode.py
+++ b/tests/test_basenode.py
@@ -5,7 +5,13 @@ from uuid import UUID, uuid4
 
 import pandas as pd
 import pytest
-from pydantic import Field, ValidationInfo, field_serializer, field_validator, ConfigDict
+from pydantic import (
+    Field,
+    ValidationInfo,
+    field_serializer,
+    field_validator,
+    ConfigDict,
+)
 
 from neontology import (
     BaseNode,
@@ -15,6 +21,7 @@ from neontology import (
     related_property,
 )
 from neontology.result import NeontologyResult
+
 
 class PracticeNode(BaseNode):
     __primaryproperty__: ClassVar[GQLIdentifier] = "pp"
@@ -999,16 +1006,20 @@ def test_create_mass_nodes(use_graph, benchmark):
 
     assert Person.get_count() == 1000
 
+
 class UserWithAliases(BaseNode):
     __primaryproperty__: ClassVar[str] = "userName"
     __primarylabel__: ClassVar[str] = "User"
     model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
-    user_name: Annotated[str, Field(alias='userName')]
-    some_other_property: Annotated[Optional[str],Field(None,alias="otherProperty")]
+    user_name: Annotated[str, Field(alias="userName")]
+    some_other_property: Annotated[Optional[str], Field(None, alias="otherProperty")]
+
 
 def test_aliased_properties(use_graph):
     user1: UserWithAliases = UserWithAliases(userName="User1")
-    user2: UserWithAliases = UserWithAliases(user_name="User2", some_other_property="alpha")
+    user2: UserWithAliases = UserWithAliases(
+        user_name="User2", some_other_property="alpha"
+    )
     user3: UserWithAliases = UserWithAliases(userName="User3", otherProperty="beta")
     assert user1.user_name == "User1"
     assert user3.some_other_property == "beta"
@@ -1025,15 +1036,14 @@ def test_aliased_properties(use_graph):
 
     result: NeontologyResult = use_graph.evaluate_query(cypher)
     assert result.nodes[0].user_name == "User1"
-    assert hasattr(result.nodes[0],"userName") ==  False
-    assert result.records_raw[0][0]['userName'] == "User1"
+    assert not hasattr(result.nodes[0], "userName")
+    assert result.records_raw[0][0]["userName"] == "User1"
     assert result.nodes[0].some_other_property is None
-    assert result.records_raw[0][0]['otherProperty'] is None
+    assert result.records_raw[0][0]["otherProperty"] is None
 
     assert result.nodes[1].user_name == "User2"
     assert result.nodes[1].some_other_property == "alpha"
-    assert result.records_raw[1][0]['otherProperty'] == "alpha"
+    assert result.records_raw[1][0]["otherProperty"] == "alpha"
 
     assert result.nodes[2].user_name == "User3"
-    assert result.records_raw[2][0]['otherProperty'] == "beta"
-    
+    assert result.records_raw[2][0]["otherProperty"] == "beta"

--- a/tests/test_baserelationship.py
+++ b/tests/test_baserelationship.py
@@ -1,6 +1,6 @@
 # type: ignore
 
-from typing import ClassVar, Optional
+from typing import ClassVar, Optional, final
 from uuid import uuid4
 
 import pandas as pd
@@ -16,7 +16,7 @@ class PracticeNode(BaseNode):
     __primarylabel__: ClassVar[Optional[str]] = "PracticeNode"
     pp: str
 
-
+@final
 class PracticeRelationship(BaseRelationship):
     __relationshiptype__: ClassVar[Optional[str]] = "PRACTICE_RELATIONSHIP"
 
@@ -87,13 +87,16 @@ def test_merge_relationship(use_graph):
 
     assert result == "Default Practice Relationship Property"
 
-
+@pytest.mark.filterwarnings("ignore:Unexpected primary labels returned \['SubclassNode'\]:UserWarning")
 def test_match_relationship(use_graph):
     source_node = PracticeNode(pp="Source Node")
     source_node.create()
 
     target_node = PracticeNode(pp="Target Node")
     target_node.create()
+
+    sub_target_node = SubclassNode(pp="Subclass Target Node", myprop="Sub")
+    sub_target_node.create()
 
     br = PracticeRelationship(
         source=source_node,
@@ -102,9 +105,22 @@ def test_match_relationship(use_graph):
     )
     br.merge()
 
+    sr = PracticeRelSecondary(
+        source=source_node,
+        target=sub_target_node,
+        practice_rel_prop="TESTING MATCH SUB NODE RELATIONSHIP")
+    sr.merge()
+
     rels = PracticeRelationship.match_relationships()
 
+    # should be only 1 Practice Relationship
+    assert len(rels) ==  1
     assert rels[0].practice_rel_prop == "TESTING MATCH RELATIONSHIP"
+    
+    #should be only 1 Secondary Relationship
+    rels_secondary = PracticeRelSecondary.match_relationships()
+    assert len(rels_secondary) ==  1
+    assert rels_secondary[0].practice_rel_prop == "TESTING MATCH SUB NODE RELATIONSHIP"
 
 
 class RelMergeOnMatchTest(PracticeRelationship):
@@ -244,8 +260,8 @@ class NewRelType(BaseRelationship):
 
     new_rel_prop: str
 
-class NewRelTypeSecondary(NewRelType):
-    """Same as NewRelType, but PracticeNode->SubClassNode instead of PracticeNode->PracticeNode"""
+class PracticeRelSecondary(PracticeRelationship):
+    """Same as PracticeRelationship, but PracticeNode->SubClassNode instead of PracticeNode->PracticeNode"""
     target: SubclassNode
 
 def test_merge_relationships_defined_types(use_graph):

--- a/tests/test_baserelationship.py
+++ b/tests/test_baserelationship.py
@@ -16,6 +16,7 @@ class PracticeNode(BaseNode):
     __primarylabel__: ClassVar[Optional[str]] = "PracticeNode"
     pp: str
 
+
 @final
 class PracticeRelationship(BaseRelationship):
     __relationshiptype__: ClassVar[Optional[str]] = "PRACTICE_RELATIONSHIP"
@@ -87,7 +88,10 @@ def test_merge_relationship(use_graph):
 
     assert result == "Default Practice Relationship Property"
 
-@pytest.mark.filterwarnings("ignore:Unexpected primary labels returned \['SubclassNode'\]:UserWarning")
+
+@pytest.mark.filterwarnings(
+    "ignore:Unexpected primary labels returned \['SubclassNode'\]:UserWarning"
+)
 def test_match_relationship(use_graph):
     source_node = PracticeNode(pp="Source Node")
     source_node.create()
@@ -108,18 +112,19 @@ def test_match_relationship(use_graph):
     sr = PracticeRelSecondary(
         source=source_node,
         target=sub_target_node,
-        practice_rel_prop="TESTING MATCH SUB NODE RELATIONSHIP")
+        practice_rel_prop="TESTING MATCH SUB NODE RELATIONSHIP",
+    )
     sr.merge()
 
     rels = PracticeRelationship.match_relationships()
 
     # should be only 1 Practice Relationship
-    assert len(rels) ==  1
+    assert len(rels) == 1
     assert rels[0].practice_rel_prop == "TESTING MATCH RELATIONSHIP"
-    
-    #should be only 1 Secondary Relationship
+
+    # should be only 1 Secondary Relationship
     rels_secondary = PracticeRelSecondary.match_relationships()
-    assert len(rels_secondary) ==  1
+    assert len(rels_secondary) == 1
     assert rels_secondary[0].practice_rel_prop == "TESTING MATCH SUB NODE RELATIONSHIP"
 
 
@@ -252,7 +257,8 @@ def test_defined_relationship_type_inherited():
 class SubclassNode(PracticeNode):
     __primarylabel__: ClassVar[Optional[str]] = "SubclassNode"
     myprop: str
-    
+
+
 class NewRelType(BaseRelationship):
     source: PracticeNode
     target: PracticeNode
@@ -260,9 +266,12 @@ class NewRelType(BaseRelationship):
 
     new_rel_prop: str
 
+
 class PracticeRelSecondary(PracticeRelationship):
     """Same as PracticeRelationship, but PracticeNode->SubClassNode instead of PracticeNode->PracticeNode"""
+
     target: SubclassNode
+
 
 def test_merge_relationships_defined_types(use_graph):
     node1 = PracticeNode(pp="Source Node")
@@ -306,8 +315,6 @@ def test_get_count(use_graph):
 
 def test_get_count_none(use_graph):
     assert NewRelType.get_count() == 0
-
-
 
 
 class NewRelType2(BaseRelationship):

--- a/tests/test_graph_connection.py
+++ b/tests/test_graph_connection.py
@@ -233,7 +233,7 @@ def test_undefined_label(use_graph):
     RETURN n
     """
 
-    with pytest.warns(UserWarning, match="Unexpected primary labels returned:"):
+    with pytest.warns(UserWarning, match="Unexpected primary labels returned"):
         result = gc.evaluate_query(match_cypher)
 
     assert len(result.records) == 2
@@ -262,7 +262,7 @@ def test_multiple_primary_labels(use_graph):
 
     with pytest.warns(
         UserWarning,
-        match=r"Unexpected primary labels returned: {('SpecialTestNodeGC'|'PracticeNodeGC'), ('SpecialTestNodeGC'|'PracticeNodeGC')}",
+        match=r"Unexpected primary labels returned \[('SpecialTestNodeGC'|'PracticeNodeGC'), ('SpecialTestNodeGC'|'PracticeNodeGC')\]",
     ):
         result = gc.evaluate_query(match_cypher)
 

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "neontolojay"
-version = "2025.0.0b1"
+version = "2025.0.0b3"
 source = { virtual = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Fix #6. Neontolojay checks the allowed source & target types before creating the relationship object and return None if not matched.

Note that it should be a discouraged code pattern to subclass concrete Node and Relationship classes. In testing this fix, I found unpredictable behavior when this is done. "Concrete" classes in this case are ones that implement the primarylabel or relationshiptype class attribute.

Best practice (documentation should be updated) is to use common abstract classes to define all shared properties, and any concrete classes that share these properties subclass only abstract classes. Mark those concrete classes with @typing.final so that type checkers help reinforce this pattern.

As part of the fix for this issue, neontology.utils.get_node_types() will stop processing subclasses when a concrete class is found. The similar behavior for get_rels_by_type() was also be implemented.