### PR TITLE
Merge behavior updated for optional, on create, and on match properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Read the original documentation [here](https://neontology.readthedocs.io/en/late
 - Support non-unique elements, optionally mapping Neo4j Element_ID into Neontolojay Node and Relationship Properties (#2)
 - Support for Pydantic Field Aliases in Property Names (#3)
 - Support multiple relationship classes with the same relationship_type (#5)
+- Merge() behavior no longer overwrites database element properties for optional fields (#8)
+- On create and on match properties are synchronized back to calling object on merge()
 
 ## Installation
 

--- a/src/neontology/basenode.py
+++ b/src/neontology/basenode.py
@@ -1,7 +1,7 @@
 import functools
 import json
 import warnings
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Self, Tuple, Union
 
 import pandas as pd
 from pydantic import ValidationError, model_validator
@@ -175,7 +175,7 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
         warnings.warn(("get_primary_property_value is deprecated, use get_pp instead."))
         return self.get_pp()
 
-    def create(self) -> "BaseNode":
+    def create(self) -> Self:
         """Create this node in the graph."""
 
         # pp = self.get_pp()
@@ -201,7 +201,7 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
         self.check_sync_result(results[0])
         return self
 
-    def merge(self) -> List["BaseNode"]:
+    def merge(self) -> List[Self]:
         """Merge this node into the graph."""
         pp_key = self.__primaryproperty__
 
@@ -216,7 +216,7 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
 
         gc = GraphConnection()
 
-        results = gc.merge_nodes(all_labels, pp_key, node_list, self.__class__)
+        results: list[Self] = gc.merge_nodes(all_labels, pp_key, node_list, self.__class__)
         assert len(results) == 1
         self.check_sync_result(results[0])
         return [self]

--- a/src/neontology/basenode.py
+++ b/src/neontology/basenode.py
@@ -216,7 +216,9 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
 
         gc = GraphConnection()
 
-        results: list[Self] = gc.merge_nodes(all_labels, pp_key, node_list, self.__class__)
+        results: list[Self] = gc.merge_nodes(
+            all_labels, pp_key, node_list, self.__class__
+        )
         assert len(results) == 1
         self.check_sync_result(results[0])
         return [self]

--- a/src/neontology/graphconnection.py
+++ b/src/neontology/graphconnection.py
@@ -122,13 +122,13 @@ class GraphConnection(object):
         self.global_rels = get_rels_by_type()
 
     def create_nodes(
-        self, labels: list, pp_key: str, properties: list, node_class: type["BaseNode"]
+        self, labels: list, pp_key: str, properties: list, node_class: type[BaseNode]
     ) -> List["BaseNode"]:
         return self.engine.create_nodes(labels, pp_key, properties, node_class)
 
     def merge_nodes(
-        self, labels: list, pp_key: str, properties: list, node_class: type["BaseNode"]
-    ) -> List["BaseNode"]:
+        self, labels: list, pp_key: str, properties: list, node_class: type[BaseNode]
+    ) -> List[BaseNode]:
         return self.engine.merge_nodes(labels, pp_key, properties, node_class)
 
     def match_nodes(

--- a/tests/test_basenode.py
+++ b/tests/test_basenode.py
@@ -666,6 +666,7 @@ def test_set_on_match(use_graph):
 
     assert cypher_result.nodes[0].only_set_on_match is None
     assert cypher_result.nodes[0].normal_field == "Bar"
+    assert test_node.only_set_on_match is None
 
     test_node2 = TestModel(only_set_on_match="Foo", normal_field="Bar", pp="test_node")
     test_node2.merge()
@@ -673,6 +674,7 @@ def test_set_on_match(use_graph):
     cypher_result2 = use_graph.evaluate_query(cypher)
 
     assert cypher_result2.nodes[0].only_set_on_match == "Foo"
+    assert test_node2.only_set_on_match == "Foo"
 
 
 def test_set_on_create(use_graph):
@@ -698,6 +700,7 @@ def test_set_on_create(use_graph):
 
     assert cypher_result.nodes[0].only_set_on_create == "Foo"
     assert cypher_result.nodes[0].normal_field == "Bar"
+    assert test_node.only_set_on_create == "Foo"
 
     test_node2 = TestModel(only_set_on_create="Fee", normal_field="Fi", pp="test_node")
     test_node2.merge()
@@ -706,6 +709,7 @@ def test_set_on_create(use_graph):
 
     assert cypher_result2.nodes[0].only_set_on_create == "Foo"
     assert cypher_result2.nodes[0].normal_field == "Fi"
+    assert test_node2.only_set_on_create == "Foo"
 
 
 class Person(BaseNode):

--- a/tests/test_basenode.py
+++ b/tests/test_basenode.py
@@ -353,12 +353,14 @@ def test_create_multiple_defined_label(use_graph):
     assert "Special Test Node" in results
     assert "Special Test Node2" in results
 
+
 class OptionalPropertyNode(BaseNode):
     __primarylabel__: ClassVar[Optional[str]] = "OptionalProperty"
     __primaryproperty__: ClassVar[str] = "pp"
 
     pp: str
     opt_prop: Optional[str] = None
+
 
 def test_merge_optional_property(use_graph):
     node_full = OptionalPropertyNode(pp="Alpha", opt_prop="Beta")
@@ -710,6 +712,59 @@ def test_set_on_create(use_graph):
     assert cypher_result2.nodes[0].only_set_on_create == "Foo"
     assert cypher_result2.nodes[0].normal_field == "Fi"
     assert test_node2.only_set_on_create == "Foo"
+
+
+def test_set_on_create_and_merge(use_graph):
+    """Check that we successfully identify field to set on match and on create
+    in same Node class"""
+
+    class TestModel(BaseNode):
+        __primaryproperty__: ClassVar[str] = "pp"
+        __primarylabel__: ClassVar[Optional[str]] = "TestModel3"
+        pp: str = "test_node"
+        only_set_on_create: str = Field(json_schema_extra={"set_on_create": True})
+        only_set_on_match: Optional[str] = Field(
+            json_schema_extra={"set_on_match": True}, default=None
+        )
+        normal_field: str
+
+    test_node = TestModel(
+        only_set_on_create="Foo",
+        only_set_on_match="Fu",
+        normal_field="Bar",
+        pp="test_node",
+    )
+    test_node.merge()
+
+    cypher = """
+    MATCH (n:TestModel3)
+    WHERE n.pp = 'test_node'
+    RETURN n
+    """
+
+    cypher_result = use_graph.evaluate_query(cypher)
+
+    assert cypher_result.nodes[0].only_set_on_match is None
+    assert cypher_result.nodes[0].only_set_on_create == "Foo"
+    assert cypher_result.nodes[0].normal_field == "Bar"
+    assert test_node.only_set_on_match is None
+    assert test_node.only_set_on_create == "Foo"
+
+    test_node2 = TestModel(
+        only_set_on_create="Fee",
+        only_set_on_match="Fa",
+        normal_field="Fi",
+        pp="test_node",
+    )
+    test_node2.merge()
+
+    cypher_result2 = use_graph.evaluate_query(cypher)
+
+    assert cypher_result2.nodes[0].only_set_on_create == "Foo"
+    assert cypher_result2.nodes[0].only_set_on_match == "Fa"
+    assert cypher_result2.nodes[0].normal_field == "Fi"
+    assert test_node2.only_set_on_create == "Foo"
+    assert test_node2.only_set_on_match == "Fa"
 
 
 class Person(BaseNode):

--- a/tests/test_basenode.py
+++ b/tests/test_basenode.py
@@ -353,6 +353,23 @@ def test_create_multiple_defined_label(use_graph):
     assert "Special Test Node" in results
     assert "Special Test Node2" in results
 
+class OptionalPropertyNode(BaseNode):
+    __primarylabel__: ClassVar[Optional[str]] = "OptionalProperty"
+    __primaryproperty__: ClassVar[str] = "pp"
+
+    pp: str
+    opt_prop: Optional[str] = None
+
+def test_merge_optional_property(use_graph):
+    node_full = OptionalPropertyNode(pp="Alpha", opt_prop="Beta")
+    node_full.merge()
+
+    node_partial = OptionalPropertyNode(pp="Alpha")
+    node_partial.merge()
+
+    # node_partial should pick up value of opt_prop from matched node on merge()
+    assert node_full.opt_prop == node_partial.opt_prop
+
 
 def test_creation_datetime(use_graph):
     """


### PR DESCRIPTION
Based on #8, merge behavior updated for the following properties on a node or relationship:

- Optional properties: can be None on the object. Now if it is None on the object, merge() will not overwrite those properties on the Server, the same as if a manual Cypher MERGE query was run without specifying those properties. See [test_merge_optional_property](https://github.com/Forgen/neontolojay/commit/d1cd480355e2939fe1bd009b37d131b5aada6f06#diff-569aac5c7dfd4264be8d87e281e79e3f1a37c36211257ebb30313e4cf7e2e0b1R363) for example.
- On Create properties: If a property is marked set_on_create, if the object is not created on a merge() this property will be reset to match the server object's value.
- On Match properties: If a property is marked set_on_match, if the object is not matched on a merge() this property will be reset to match the server object's value. 

See new [test_set_on_create_and_merge](https://github.com/Forgen/neontolojay/commit/7d58b6636bf6f0e023d102ca9197849520fd6fa3#diff-569aac5c7dfd4264be8d87e281e79e3f1a37c36211257ebb30313e4cf7e2e0b1R717) for the expected behavior of a node with both on_create and on_match properties.