### PR TITLE
Non unique node merge() fixes 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neontolojay"
-version = "2025.0.0b3"
+version = "2025.0.0b4"
 requires-python = ">=3.9"
 description = "A Python package for modelling data in a Neo4j graph database with Pydantic and Pandas. A fork of neontology with added support for non-unique primary keys."
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "neontolojay"
-version = "2025.0.0b4"
+version = "2025.0.0b5"
 requires-python = ">=3.9"
 description = "A Python package for modelling data in a Neo4j graph database with Pydantic and Pandas. A fork of neontology with added support for non-unique primary keys."
 dependencies = [

--- a/src/neontology/basenode.py
+++ b/src/neontology/basenode.py
@@ -356,25 +356,9 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
             Optional[B]: If the node exists, return it as an instance.
         """
 
-        cypher = f"""
-        MATCH (n:{cls.__primarylabel__})
-        WHERE n.{cls.__primaryproperty__} = $pp
-        RETURN n
-        """
-
-        params = {"pp": pp}
-
         gc = GraphConnection()
 
-        result = gc.evaluate_query(
-            cypher, params, node_classes={cls.__primarylabel__: cls}
-        )
-
-        if result.nodes:
-            return result.nodes[0]
-
-        else:
-            return None
+        return gc.match_node(pp, cls)
 
     @classmethod
     def delete(cls, pp: str) -> None:

--- a/src/neontology/basenode.py
+++ b/src/neontology/basenode.py
@@ -205,11 +205,6 @@ class BaseNode(CommonModel):  # pyre-ignore[13]
         """Merge this node into the graph."""
         pp_key = self.__primaryproperty__
 
-        element_id_prop_name = getattr(self, "__elementidproperty__", None)
-        if pp_key == element_id_prop_name:
-            # Special handeling for primary property of element_id
-            return [self.create()]
-
         node_list = [self._get_merge_parameters()]
 
         all_labels = [self.__primarylabel__] + self.__secondarylabels__

--- a/src/neontology/graphconnection.py
+++ b/src/neontology/graphconnection.py
@@ -130,7 +130,20 @@ class GraphConnection(object):
         self, labels: list, pp_key: str, properties: list, node_class: type[BaseNode]
     ) -> List[BaseNode]:
         return self.engine.merge_nodes(labels, pp_key, properties, node_class)
+    
+    def match_node(self, pp: str, node_class: type[BaseNode]) -> Optional["BaseNode"]:
+        """MATCH a single node of this type with the given primary property.
 
+        Args:
+            pp (str): The value of the primary property (pp) to match on.
+            node_class (type[BaseNode]): Class of the node to match
+
+        Returns:
+            Optional[B]: If the node exists, return it as an instance.
+        """
+
+        return self.engine.match_node(pp,node_class)
+        
     def match_nodes(
         self,
         node_class: type["BaseNode"],

--- a/src/neontology/graphconnection.py
+++ b/src/neontology/graphconnection.py
@@ -130,7 +130,7 @@ class GraphConnection(object):
         self, labels: list, pp_key: str, properties: list, node_class: type[BaseNode]
     ) -> List[BaseNode]:
         return self.engine.merge_nodes(labels, pp_key, properties, node_class)
-    
+
     def match_node(self, pp: str, node_class: type[BaseNode]) -> Optional["BaseNode"]:
         """MATCH a single node of this type with the given primary property.
 
@@ -142,8 +142,8 @@ class GraphConnection(object):
             Optional[B]: If the node exists, return it as an instance.
         """
 
-        return self.engine.match_node(pp,node_class)
-        
+        return self.engine.match_node(pp, node_class)
+
     def match_nodes(
         self,
         node_class: type["BaseNode"],

--- a/src/neontology/graphengines/graphengine.py
+++ b/src/neontology/graphengines/graphengine.py
@@ -127,9 +127,15 @@ class GraphEngineBase:
 
         label_identifiers = [gql_identifier_adapter.validate_strings(x) for x in labels]
 
+        element_id_prop_name = getattr(node_class, "__elementidproperty__", None)
+        if node_class.__primaryproperty__ == element_id_prop_name:
+            pp_cypher = ""
+        else:
+            pp_cypher = f"{{{gql_identifier_adapter.validate_strings(pp_key)}: node.pp}}"
+
         cypher = f"""
         UNWIND $node_list AS node
-        create (n:{":".join(label_identifiers)} {{{gql_identifier_adapter.validate_strings(pp_key)}: node.pp}})
+        create (n:{":".join(label_identifiers)} {pp_cypher})
         SET n += node.props
         RETURN n
         """
@@ -261,10 +267,15 @@ class GraphEngineBase:
         Returns:
             Optional[B]: If the node exists, return it as an instance.
         """
+        element_id_prop_name = getattr(node_class, "__elementidproperty__", None)
+        if node_class.__primaryproperty__ == element_id_prop_name:
+            match_cypher = "elementId(n)"
+        else:
+            match_cypher = f"n.{node_class.__primaryproperty__}"
 
         cypher = f"""
         MATCH (n:{node_class.__primarylabel__})
-        WHERE n.{node_class.__primaryproperty__} = $pp
+        WHERE {match_cypher} = $pp
         RETURN n
         """
 

--- a/src/neontology/graphengines/graphengine.py
+++ b/src/neontology/graphengines/graphengine.py
@@ -250,7 +250,36 @@ class GraphEngineBase:
         return self.evaluate_query(
             cypher, params, node_classes=node_classes, relationship_classes=rel_types
         )
+    
+    def match_node(self, pp: str, node_class: type[BaseNode]) -> Optional[BaseNode]:
+        """MATCH a single node of this type with the given primary property.
 
+        Args:
+            pp (str): The value of the primary property (pp) to match on.
+            node_class (type[BaseNode]): Class of the node to match
+
+        Returns:
+            Optional[B]: If the node exists, return it as an instance.
+        """
+
+        cypher = f"""
+        MATCH (n:{node_class.__primarylabel__})
+        WHERE n.{node_class.__primaryproperty__} = $pp
+        RETURN n
+        """
+
+        params = {"pp": pp}
+
+        result = self.evaluate_query(
+            cypher, params, node_classes={node_class.__primarylabel__: node_class}
+        )
+
+        if result.nodes:
+            return result.nodes[0]
+
+        else:
+            return None
+        
     def match_nodes(
         self,
         node_class: type["BaseNode"],

--- a/src/neontology/graphengines/memgraphengine.py
+++ b/src/neontology/graphengines/memgraphengine.py
@@ -77,7 +77,42 @@ class MemgraphEngine(GraphEngineBase):
 
         else:
             return None
+        
+    def match_node(self, pp: str, node_class: type["BaseNode"]) -> Optional["BaseNode"]:
+        """MATCH a single node of this type with the given primary property.
+        Memgraph specific element id function version
 
+        Args:
+            pp (str): The value of the primary property (pp) to match on.
+            node_class (type[BaseNode]): Class of the node to match
+
+        Returns:
+            Optional[B]: If the node exists, return it as an instance.
+        """
+        element_id_prop_name = getattr(node_class, "__elementidproperty__", None)
+        if node_class.__primaryproperty__ == element_id_prop_name:
+            match_cypher = "toString(id(n))"
+        else:
+            match_cypher = f"n.{node_class.__primaryproperty__}"
+
+        cypher = f"""
+        MATCH (n:{node_class.__primarylabel__})
+        WHERE {match_cypher} = $pp
+        RETURN n
+        """
+
+        params = {"pp": pp}
+
+        result = self.evaluate_query(
+            cypher, params, node_classes={node_class.__primarylabel__: node_class}
+        )
+
+        if result.nodes:
+            return result.nodes[0]
+
+        else:
+            return None
+        
     def merge_relationships(
         self,
         source_label: str,
@@ -89,6 +124,7 @@ class MemgraphEngine(GraphEngineBase):
         rel_props: List[dict],
         rel_class: type["BaseRelationship"],
     ) -> NeontologyResult:
+        """Merge relationships - memgraph specific element id function version"""
         # build a string of properties to merge on "prop_name: $prop_name"
         merge_props = ", ".join(
             [

--- a/src/neontology/graphengines/memgraphengine.py
+++ b/src/neontology/graphengines/memgraphengine.py
@@ -77,7 +77,7 @@ class MemgraphEngine(GraphEngineBase):
 
         else:
             return None
-        
+
     def match_node(self, pp: str, node_class: type["BaseNode"]) -> Optional["BaseNode"]:
         """MATCH a single node of this type with the given primary property.
         Memgraph specific element id function version
@@ -112,7 +112,11 @@ class MemgraphEngine(GraphEngineBase):
 
         else:
             return None
-        
+
+    @staticmethod
+    def _where_elementId_cypher() -> str:
+        return "toString(id(n)) = $pp"
+
     def merge_relationships(
         self,
         source_label: str,

--- a/tests/test_basenode.py
+++ b/tests/test_basenode.py
@@ -180,8 +180,9 @@ def test_none_primary_label():
         __primarylabel__: ClassVar[Optional[str]] = None
         pp: str
 
-    with pytest.raises(NotImplementedError):
-        SpecialPracticeNode(pp="Test Node")
+    with pytest.warns(UserWarning,match="Primary Label should contain only alphanumeric characters and underscores"):
+        with pytest.raises(NotImplementedError):
+            SpecialPracticeNode(pp="Test Node")
 
 
 def test_create_multilabel(use_graph):

--- a/tests/test_basenode.py
+++ b/tests/test_basenode.py
@@ -180,7 +180,10 @@ def test_none_primary_label():
         __primarylabel__: ClassVar[Optional[str]] = None
         pp: str
 
-    with pytest.warns(UserWarning,match="Primary Label should contain only alphanumeric characters and underscores"):
+    with pytest.warns(
+        UserWarning,
+        match="Primary Label should contain only alphanumeric characters and underscores",
+    ):
         with pytest.raises(NotImplementedError):
             SpecialPracticeNode(pp="Test Node")
 

--- a/tests/test_nonunique.py
+++ b/tests/test_nonunique.py
@@ -25,6 +25,7 @@ class ParentUniqueRelationship(BaseRelationship, ElementIdModel):
     source: NonUniqueNode
     target: UniqueNode
 
+
 def test_match_nonunique(use_graph):
     tn = NonUniqueNode(nonpp="Special Test Node")
 
@@ -36,11 +37,12 @@ def test_match_nonunique(use_graph):
 
     assert "Special Test Node" == result.nonpp
 
+
 def test_merge_nonunique(use_graph):
-    child1_node = NonUniqueNode(nonpp="Child", element_id='150')
+    child1_node = NonUniqueNode(nonpp="Child", element_id="150")
     child1_node.merge()
     child1_elementid = child1_node.element_id
-    print(f'{child1_elementid=}')
+    print(f"{child1_elementid=}")
     # check server element id is stable by merging twice to ensure child1 isn't duplicated
     child1_node.merge()
     assert child1_node.element_id == child1_elementid
@@ -50,9 +52,9 @@ def test_merge_nonunique(use_graph):
     rel1 = ParentUniqueRelationship(source=child1_node, target=parent1_node)
     rel1.merge()
 
-    child2_node = NonUniqueNode(nonpp="Child", element_id='250')
+    child2_node = NonUniqueNode(nonpp="Child", element_id="250")
     child2_node.merge()
-    parent2_node = UniqueNode(pp="Parent2", element_id='5678')
+    parent2_node = UniqueNode(pp="Parent2", element_id="5678")
     parent2_node.merge()
     rel2 = ParentUniqueRelationship(source=child2_node, target=parent2_node)
     rel2.merge()
@@ -116,7 +118,7 @@ def test_create_nonunique(use_graph):
     """
     result_elid = use_graph.evaluate_query_single(cypher_elid)
     assert result_elid is None
-    
+
     cypher_elid = """
     MATCH (n:NonUniqueNode {nonpp:'Child'}) RETURN n.element_id LIMIT 1
     """

--- a/tests/test_nonunique.py
+++ b/tests/test_nonunique.py
@@ -25,6 +25,16 @@ class ParentUniqueRelationship(BaseRelationship, ElementIdModel):
     source: NonUniqueNode
     target: UniqueNode
 
+def test_match_nonunique(use_graph):
+    tn = NonUniqueNode(nonpp="Special Test Node")
+
+    tn.create()
+
+    result = NonUniqueNode.match(pp=tn.element_id)
+
+    assert isinstance(result, NonUniqueNode)
+
+    assert "Special Test Node" == result.nonpp
 
 def test_merge_nonunique(use_graph):
     child1_node = NonUniqueNode(nonpp="Child", element_id='150')

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "neontolojay"
-version = "2025.0.0b3"
+version = "2025.0.0b4"
 source = { virtual = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Merge non_unique branch to main. Bump to 2025.0.0b5. Fix bugs for https://github.com/Forgen/neontolojay/issues/2 identified in .0b3. Added addition test_nonunique coverage for on create and on match properties for an element ID primary property node class (NonUniqueNodes).

- NonUniqueNodes have proper merge() behavior. Previously they would always create new nodes and never match. Now the merge is fully functional and includes on create and on match property funcitonality. 
- "element_id" property is no longer getting committed to graph database.